### PR TITLE
Simplified installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,8 @@ A pack of files, configs and aliases to help with git
 - install Sublime 3 Text editor
 
 ```
-cd ~
-mkdir -p www
-cd www
-git clone https://github.com/MortalFlesh/git-files.git
-cd git-files
+git clone https://github.com/MortalFlesh/git-files.git ~/www/git-files
+cd ~/www/git-files
 ./install.sh
 ```
 


### PR DESCRIPTION
The `git-clone` command accepts directory path as a second argument. If the directory doesn't exist, it is created, including every possibly missing ancestor, and only if the directory already exists and is nonempty, the cloning is aborted. That is exactly the desired effect of `mkdir -p`, and it doesn't introduce any new confusing use-cases.

Also, while I'm here, the `~` tilde can be ommited in `cd ~` command. Just running `cd` without arguments moves you to home directory just as well :)