### PR TITLE
Gitconfig - merge conflict visualization tweak

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -6,6 +6,8 @@
   excludesfile = ~/.gitignore_global
   editor = sublime -n -w
   ignorecase = false
+[merge]
+    conflictstyle = diff3
 [difftool "sourcetree"]
 	cmd = opendiff \"$LOCAL\" \"$REMOTE\"
 	path = 


### PR DESCRIPTION
Display not only both conflicting versions, but also their last common
ancestor. This displays introduced changes in much more understandable
way.

See https://stackoverflow.com/a/27417871